### PR TITLE
Issue with docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 
 # 👇 pin Crystal to 1.12.x (works with Kemal 1.5.0)
 RUN apt-get update && apt-get install -y \
-    crystal=1.12.2-1 \
+    crystal=1.12.2-139 \
     libssl-dev \
     libyaml-dev \
     libsqlite3-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN apt-get update && apt-get install -y \
     && curl -fsSL https://packagecloud.io/84codes/crystal/gpgkey | gpg --dearmor > /etc/apt/trusted.gpg.d/84codes_crystal.gpg \
     && echo "deb [signed-by=/etc/apt/trusted.gpg.d/84codes_crystal.gpg] https://packagecloud.io/84codes/crystal/debian/ bookworm main" > /etc/apt/sources.list.d/84codes_crystal.list
 
+# 👇 pin Crystal to 1.12.x (works with Kemal 1.5.0)
 RUN apt-get update && apt-get install -y \
-    crystal \
+    crystal=1.12.2-1 \
     libssl-dev \
     libyaml-dev \
     libsqlite3-dev \


### PR DESCRIPTION
Due to a incompatibility with Kamel and Crystal a specific version for crystal was chosen in dockerfile. 

Issue: 2025-Sep-07 10:00:28.059206
#0 building with "default" instance using docker driver
2025-Sep-07 10:00:28.059206
2025-Sep-07 10:00:28.059206
#1 [internal] load build definition from Dockerfile
2025-Sep-07 10:00:28.059206
#1 transferring dockerfile: 640B done
2025-Sep-07 10:00:28.059206
#1 DONE 0.0s
2025-Sep-07 10:00:28.059206
2025-Sep-07 10:00:28.059206
#2 [internal] load metadata for docker.io/library/alpine:edge
2025-Sep-07 10:00:28.593364
#2 DONE 0.7s
2025-Sep-07 10:00:28.793960
#3 [internal] load .dockerignore
2025-Sep-07 10:00:28.793960
#3 transferring context: 77B done
2025-Sep-07 10:00:28.793960
#3 DONE 0.0s
2025-Sep-07 10:00:28.793960
2025-Sep-07 10:00:28.793960
#4 [build 1/6] FROM docker.io/library/alpine:edge@sha256:115729ec5cb049ba6359c3ab005ac742012d92bbaa5b8bc1a878f1e8f62c0cb8
2025-Sep-07 10:00:28.793960
#4 DONE 0.0s
2025-Sep-07 10:00:28.793960
2025-Sep-07 10:00:28.793960
#5 [runtime 3/7] RUN apk add --no-cache     gc     pcre2     libevent     yaml     sqlite-libs     openssl
2025-Sep-07 10:00:28.793960
#5 CACHED
2025-Sep-07 10:00:28.793960
2025-Sep-07 10:00:28.793960
#6 [build 2/6] WORKDIR /usr/src/app
2025-Sep-07 10:00:28.793960
#6 CACHED
2025-Sep-07 10:00:28.793960
2025-Sep-07 10:00:28.793960
#7 [runtime 4/7] RUN mkdir -p sqlite
2025-Sep-07 10:00:28.793960
#7 CACHED
2025-Sep-07 10:00:28.793960
2025-Sep-07 10:00:28.793960
#8 [internal] load build context
2025-Sep-07 10:00:28.793960
#8 transferring context: 254.16kB 0.0s done
2025-Sep-07 10:00:28.793960
#8 DONE 0.0s
2025-Sep-07 10:00:28.793960
2025-Sep-07 10:00:28.793960
#9 [build 3/6] RUN apk update && apk add --no-cache     crystal     shards     yaml-dev     sqlite-dev     openssl-dev
2025-Sep-07 10:00:28.793960
#9 CACHED
2025-Sep-07 10:00:28.793960
2025-Sep-07 10:00:28.793960
#10 [build 4/6] COPY . .
2025-Sep-07 10:00:28.793960
#10 DONE 0.1s
2025-Sep-07 10:00:28.899089
#11 [build 5/6] RUN shards install
2025-Sep-07 10:00:28.899089
#11 0.083 I: Resolving dependencies
2025-Sep-07 10:00:28.899089
#11 0.103 I: Fetching https://github.com/kemalcr/kemal.git
2025-Sep-07 10:00:29.057344
#11 0.105 I: Fetching https://github.com/crystal-lang/crystal-sqlite3.git
2025-Sep-07 10:00:29.057344
#11 0.105 I: Fetching https://github.com/fridgerator/crecto.git
2025-Sep-07 10:00:29.057344
#11 0.107 I: Fetching https://github.com/amberframework/micrate.git
2025-Sep-07 10:00:29.057344
#11 0.108 I: Fetching https://github.com/busyloop/user_agent_parser.git
2025-Sep-07 10:00:29.057344
#11 0.108 I: Fetching https://github.com/gdotdesign/cr-dotenv.git
2025-Sep-07 10:00:29.057344
#11 0.108 I: Fetching https://github.com/kemalcr/spec-kemal.git
2025-Sep-07 10:00:30.250730
#11 1.454 I: Fetching https://github.com/luislavena/radix.git
2025-Sep-07 10:00:30.401753
#11 1.455 I: Fetching https://github.com/crystal-loot/exception_page.git
2025-Sep-07 10:00:31.043798
#11 2.247 I: Fetching https://github.com/sija/backtracer.cr.git
2025-Sep-07 10:00:31.821794
#11 3.025 I: Fetching https://github.com/crystal-lang/crystal-db.git
2025-Sep-07 10:00:32.808764
#11 4.013 I: Fetching https://github.com/will/crystal-pg.git
2025-Sep-07 10:00:32.960541
#11 4.014 I: Fetching https://github.com/crystal-lang/crystal-mysql.git
2025-Sep-07 10:00:35.004188
#11 6.208 I: Installing radix (0.4.1)
2025-Sep-07 10:00:35.111610
#11 6.222 I: Installing backtracer (1.2.2)
2025-Sep-07 10:00:35.111610
#11 6.235 I: Installing exception_page (0.4.1)
2025-Sep-07 10:00:35.111610
#11 6.247 I: Installing kemal (1.5.0)
2025-Sep-07 10:00:35.111610
#11 6.271 I: Installing db (0.11.0)
2025-Sep-07 10:00:35.111610
#11 6.290 I: Installing crecto (0.12.1)
2025-Sep-07 10:00:35.111610
#11 6.315 I: Installing pg (0.26.0)
2025-Sep-07 10:00:35.320443
#11 6.336 I: Installing mysql (0.14.0)
2025-Sep-07 10:00:35.320443
#11 6.350 I: Installing sqlite3 (0.19.0)
2025-Sep-07 10:00:35.320443
#11 6.364 I: Installing micrate (0.15.1)
2025-Sep-07 10:00:35.320443
#11 6.374 I: Postinstall of micrate: shards build
2025-Sep-07 10:00:49.947133
#11 21.15 I: Installing user_agent_parser (2.0.1)
2025-Sep-07 10:00:49.950378
2025-Sep-07 10:00:50.109233
#11 21.16 I: Installing dotenv (1.0.0)
2025-Sep-07 10:00:50.109233
#11 21.16 I: Installing spec-kemal (1.0.0)
2025-Sep-07 10:00:50.323822
#11 DONE 21.5s
2025-Sep-07 10:00:50.539731
#12 [build 6/6] RUN shards build --release --no-debug
2025-Sep-07 10:00:50.539731
#12 0.064 I: Dependencies are satisfied
2025-Sep-07 10:00:50.539731
#12 0.064 I: Building: bit
2025-Sep-07 10:01:10.759123
#12 20.43 E: Error target bit failed to compile:
2025-Sep-07 10:01:10.759123
#12 20.43 Showing last frame. Use --error-trace for full trace.
2025-Sep-07 10:01:10.759123
#12 20.43
2025-Sep-07 10:01:10.759123
#12 20.43 In lib/kemal/src/kemal/static_file_handler.cr:61:47
2025-Sep-07 10:01:10.759123
#12 20.43
2025-Sep-07 10:01:10.759123
#12 20.43  61 | directory_listing(context.response, request_path, file_path)
2025-Sep-07 10:01:10.759123
#12 20.43                                           ^-----------
2025-Sep-07 10:01:10.759123
#12 20.43 Error: expected argument #2 to 'Kemal::StaticFileHandler#directory_listing' to be Path, not String
2025-Sep-07 10:01:10.759123
#12 20.43
2025-Sep-07 10:01:10.759123
#12 20.43 Overloads are:
2025-Sep-07 10:01:10.759123
#12 20.43  - HTTP::StaticFileHandler#directory_listing(io : IO, request_path : Path, path : Path)
2025-Sep-07 10:01:10.759123
#12 20.43
2025-Sep-07 10:01:10.847452
#12 ERROR: process "/bin/sh -c shards build --release --no-debug" did not complete successfully: exit code: 1
2025-Sep-07 10:01:10.847452
------
2025-Sep-07 10:01:10.847452
> [build 6/6] RUN shards build --release --no-debug:
2025-Sep-07 10:01:10.847452
20.43
2025-Sep-07 10:01:10.847452
20.43 In lib/kemal/src/kemal/static_file_handler.cr:61:47
2025-Sep-07 10:01:10.847452
20.43
2025-Sep-07 10:01:10.847452
20.43  61 | directory_listing(context.response, request_path, file_path)
2025-Sep-07 10:01:10.847452
20.43                                           ^-----------
2025-Sep-07 10:01:10.847452
20.43 Error: expected argument #2 to 'Kemal::StaticFileHandler#directory_listing' to be Path, not String
2025-Sep-07 10:01:10.847452
20.43
2025-Sep-07 10:01:10.847452
20.43 Overloads are:
2025-Sep-07 10:01:10.847452
20.43  - HTTP::StaticFileHandler#directory_listing(io : IO, request_path : Path, path : Path)
2025-Sep-07 10:01:10.847452
20.43
2025-Sep-07 10:01:10.852729
------
2025-Sep-07 10:01:10.852729
Dockerfile:16
2025-Sep-07 10:01:10.852729
--------------------
2025-Sep-07 10:01:10.852729
14 |
2025-Sep-07 10:01:10.852729
15 |     RUN shards install
2025-Sep-07 10:01:10.852729
16 | >>> RUN shards build --release --no-debug
2025-Sep-07 10:01:10.852729
17 |
2025-Sep-07 10:01:10.852729
18 |     FROM alpine:edge AS runtime
2025-Sep-07 10:01:10.852729
--------------------
2025-Sep-07 10:01:10.852729
ERROR: failed to build: failed to solve: process "/bin/sh -c shards build --release --no-debug" did not complete successfully: exit code: 1
2025-Sep-07 10:01:10.855796
exit status 1
2025-Sep-07 10:01:10.913767
Oops something is not okay, are you okay? 😢
2025-Sep-07 10:01:10.917838
#0 building with "default" instance using docker driver
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#1 [internal] load build definition from Dockerfile
2025-Sep-07 10:01:10.917838
#1 transferring dockerfile: 640B done
2025-Sep-07 10:01:10.917838
#1 DONE 0.0s
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#2 [internal] load metadata for docker.io/library/alpine:edge
2025-Sep-07 10:01:10.917838
#2 DONE 0.7s
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#3 [internal] load .dockerignore
2025-Sep-07 10:01:10.917838
#3 transferring context: 77B done
2025-Sep-07 10:01:10.917838
#3 DONE 0.0s
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#4 [build 1/6] FROM docker.io/library/alpine:edge@sha256:115729ec5cb049ba6359c3ab005ac742012d92bbaa5b8bc1a878f1e8f62c0cb8
2025-Sep-07 10:01:10.917838
#4 DONE 0.0s
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#5 [runtime 3/7] RUN apk add --no-cache     gc     pcre2     libevent     yaml     sqlite-libs     openssl
2025-Sep-07 10:01:10.917838
#5 CACHED
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#6 [build 2/6] WORKDIR /usr/src/app
2025-Sep-07 10:01:10.917838
#6 CACHED
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#7 [runtime 4/7] RUN mkdir -p sqlite
2025-Sep-07 10:01:10.917838
#7 CACHED
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#8 [internal] load build context
2025-Sep-07 10:01:10.917838
#8 transferring context: 254.16kB 0.0s done
2025-Sep-07 10:01:10.917838
#8 DONE 0.0s
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#9 [build 3/6] RUN apk update && apk add --no-cache     crystal     shards     yaml-dev     sqlite-dev     openssl-dev
2025-Sep-07 10:01:10.917838
#9 CACHED
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#10 [build 4/6] COPY . .
2025-Sep-07 10:01:10.917838
#10 DONE 0.1s
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#11 [build 5/6] RUN shards install
2025-Sep-07 10:01:10.917838
#11 0.083 I: Resolving dependencies
2025-Sep-07 10:01:10.917838
#11 0.103 I: Fetching https://github.com/kemalcr/kemal.git
2025-Sep-07 10:01:10.917838
#11 0.105 I: Fetching https://github.com/crystal-lang/crystal-sqlite3.git
2025-Sep-07 10:01:10.917838
#11 0.105 I: Fetching https://github.com/fridgerator/crecto.git
2025-Sep-07 10:01:10.917838
#11 0.107 I: Fetching https://github.com/amberframework/micrate.git
2025-Sep-07 10:01:10.917838
#11 0.108 I: Fetching https://github.com/busyloop/user_agent_parser.git
2025-Sep-07 10:01:10.917838
#11 0.108 I: Fetching https://github.com/gdotdesign/cr-dotenv.git
2025-Sep-07 10:01:10.917838
#11 0.108 I: Fetching https://github.com/kemalcr/spec-kemal.git
2025-Sep-07 10:01:10.917838
#11 1.454 I: Fetching https://github.com/luislavena/radix.git
2025-Sep-07 10:01:10.917838
#11 1.455 I: Fetching https://github.com/crystal-loot/exception_page.git
2025-Sep-07 10:01:10.917838
#11 2.247 I: Fetching https://github.com/sija/backtracer.cr.git
2025-Sep-07 10:01:10.917838
#11 3.025 I: Fetching https://github.com/crystal-lang/crystal-db.git
2025-Sep-07 10:01:10.917838
#11 4.013 I: Fetching https://github.com/will/crystal-pg.git
2025-Sep-07 10:01:10.917838
#11 4.014 I: Fetching https://github.com/crystal-lang/crystal-mysql.git
2025-Sep-07 10:01:10.917838
#11 6.208 I: Installing radix (0.4.1)
2025-Sep-07 10:01:10.917838
#11 6.222 I: Installing backtracer (1.2.2)
2025-Sep-07 10:01:10.917838
#11 6.235 I: Installing exception_page (0.4.1)
2025-Sep-07 10:01:10.917838
#11 6.247 I: Installing kemal (1.5.0)
2025-Sep-07 10:01:10.917838
#11 6.271 I: Installing db (0.11.0)
2025-Sep-07 10:01:10.917838
#11 6.290 I: Installing crecto (0.12.1)
2025-Sep-07 10:01:10.917838
#11 6.315 I: Installing pg (0.26.0)
2025-Sep-07 10:01:10.917838
#11 6.336 I: Installing mysql (0.14.0)
2025-Sep-07 10:01:10.917838
#11 6.350 I: Installing sqlite3 (0.19.0)
2025-Sep-07 10:01:10.917838
#11 6.364 I: Installing micrate (0.15.1)
2025-Sep-07 10:01:10.917838
#11 6.374 I: Postinstall of micrate: shards build
2025-Sep-07 10:01:10.917838
#11 21.15 I: Installing user_agent_parser (2.0.1)
2025-Sep-07 10:01:10.917838
#11 21.16 I: Installing dotenv (1.0.0)
2025-Sep-07 10:01:10.917838
#11 21.16 I: Installing spec-kemal (1.0.0)
2025-Sep-07 10:01:10.917838
#11 DONE 21.5s
2025-Sep-07 10:01:10.917838
2025-Sep-07 10:01:10.917838
#12 [build 6/6] RUN shards build --release --no-debug
2025-Sep-07 10:01:10.917838
#12 0.064 I: Dependencies are satisfied
2025-Sep-07 10:01:10.917838
#12 0.064 I: Building: bit
2025-Sep-07 10:01:10.917838
#12 20.43 E: Error target bit failed to compile:
2025-Sep-07 10:01:10.917838
#12 20.43 Showing last frame. Use --error-trace for full trace.
2025-Sep-07 10:01:10.917838
#12 20.43
2025-Sep-07 10:01:10.917838
#12 20.43 In lib/kemal/src/kemal/static_file_handler.cr:61:47
2025-Sep-07 10:01:10.917838
#12 20.43
2025-Sep-07 10:01:10.917838
#12 20.43  61 | directory_listing(context.response, request_path, file_path)
2025-Sep-07 10:01:10.917838
#12 20.43                                           ^-----------
2025-Sep-07 10:01:10.917838
#12 20.43 Error: expected argument #2 to 'Kemal::StaticFileHandler#directory_listing' to be Path, not String
2025-Sep-07 10:01:10.917838
#12 20.43
2025-Sep-07 10:01:10.917838
#12 20.43 Overloads are:
2025-Sep-07 10:01:10.917838
#12 20.43  - HTTP::StaticFileHandler#directory_listing(io : IO, request_path : Path, path : Path)
2025-Sep-07 10:01:10.917838
#12 20.43
2025-Sep-07 10:01:10.917838
#12 ERROR: process "/bin/sh -c shards build --release --no-debug" did not complete successfully: exit code: 1
2025-Sep-07 10:01:10.917838
------
2025-Sep-07 10:01:10.917838
> [build 6/6] RUN shards build --release --no-debug:
2025-Sep-07 10:01:10.917838
20.43
2025-Sep-07 10:01:10.917838
20.43 In lib/kemal/src/kemal/static_file_handler.cr:61:47
2025-Sep-07 10:01:10.917838
20.43
2025-Sep-07 10:01:10.917838
20.43  61 | directory_listing(context.response, request_path, file_path)
2025-Sep-07 10:01:10.917838
20.43                                           ^-----------
2025-Sep-07 10:01:10.917838
20.43 Error: expected argument #2 to 'Kemal::StaticFileHandler#directory_listing' to be Path, not String
2025-Sep-07 10:01:10.917838
20.43
2025-Sep-07 10:01:10.917838
20.43 Overloads are:
2025-Sep-07 10:01:10.917838
20.43  - HTTP::StaticFileHandler#directory_listing(io : IO, request_path : Path, path : Path)
2025-Sep-07 10:01:10.917838
20.43
2025-Sep-07 10:01:10.917838
------
2025-Sep-07 10:01:10.917838
Dockerfile:16
2025-Sep-07 10:01:10.917838
--------------------
2025-Sep-07 10:01:10.917838
14 |
2025-Sep-07 10:01:10.917838
15 |     RUN shards install
2025-Sep-07 10:01:10.917838
16 | >>> RUN shards build --release --no-debug
2025-Sep-07 10:01:10.917838
17 |
2025-Sep-07 10:01:10.917838
18 |     FROM alpine:edge AS runtime
2025-Sep-07 10:01:10.917838
--------------------
2025-Sep-07 10:01:10.917838
ERROR: failed to build: failed to solve: process "/bin/sh -c shards build --release --no-debug" did not complete successfully: exit code: 1
2025-Sep-07 10:01:10.917838
exit status 1
2025-Sep-07 10:01:10.921976
Deployment failed. Removing the new version of your application.